### PR TITLE
adding error in response body as json with full exception

### DIFF
--- a/KestrelMock/Startup.cs
+++ b/KestrelMock/Startup.cs
@@ -39,7 +39,6 @@ namespace KestrelMock
 
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 		{
-			app.UseDeveloperExceptionPage();
 			app.UseMockService();
 		}
 	}


### PR DESCRIPTION
@JasonRowe I have added the response as error if any error occurs at runtime,
so we have a way to detect possible problems or get some feedback from users of the mock,
not elegant but should be fine.

I also removed the developer error page, as now the error is always returned as json

```json
{  "error" : "full system exception ToString value, including nested ex and stacktrace" }
```