### PR TITLE
Implement HTTP verb matching

### DIFF
--- a/KestrelMock.Tests/appsettings.json
+++ b/KestrelMock.Tests/appsettings.json
@@ -17,6 +17,21 @@
 		},
 		{
 			"Request": {
+				"Methods": [ "PUT" ],
+				"PathStartsWith": "/starts/with"
+			},
+			"Response": {
+				"Status": 200,
+				"Headers": [
+					{
+						"Content-Type": "application/json"
+					}
+				],
+				"Body": "{\"banana_x\": 8000_put}"
+			}
+		},
+		{
+			"Request": {
 				"Methods": [ "GET" ],
 				"PathMatchesRegex": ".+\\d{4}.+"
 			},
@@ -32,7 +47,22 @@
 		},
 		{
 			"Request": {
-				"Methods": [ "POST", "GET" ],
+				"Methods": [ "PUT" ],
+				"PathMatchesRegex": ".+\\d{4}.+"
+			},
+			"Response": {
+				"Status": 200,
+				"Headers": [
+					{
+						"Content-Type": "application/json"
+					}
+				],
+				"Body": "{\"regex_is_working_put\": 808}"
+			}
+		},
+		{
+			"Request": {
+				"Methods": [ "PUT", "POST", "GET" ],
 				"Path": "/hello/world"
 			},
 			"Response": {
@@ -42,12 +72,12 @@
 						"Content-Type": "application/json"
 					}
 				],
-				"Body": "{\"hello\": \"world\"}"
+				"Body": "{\"hello\": \"world put post and get\"}"
 			}
 		},
 		{
 			"Request": {
-				"Methods": [ "POST" ],
+				"Methods": [ "POST", "PUT" ],
 				"Path": "/api/estimate",
 				"BodyContains": "00000"
 			},
@@ -58,12 +88,12 @@
 						"Content-Type": "application/json"
 					}
 				],
-				"Body": "BodyContains Works!"
+				"Body": "BodyContains Works for PUT and POST!"
 			}
 		},
 		{
 			"Request": {
-				"Methods": [ "POST" ],
+				"Methods": [ "POST", "PUT" ],
 				"Path": "/api/estimate",
 				"BodyDoesNotContain": "00000"
 			},
@@ -74,7 +104,7 @@
 						"Content-Type": "application/json"
 					}
 				],
-				"Body": "BodyDoesNotContain works!!"
+				"Body": "BodyDoesNotContain works for PUT and POST!!"
 			}
 		},
 		{
@@ -106,69 +136,69 @@
 				],
 				"Body": "Bad Gateway! Bad!"
 			}
-    },
-    {
-      "Request": {
-        "Methods": [ "GET" ],
-        "PathStartsWith": "/api/orders"
-      },
-      "Response": {
-        "Status": 200,
-        "Headers": [
-          {
-            "Content-Type": "application/json"
-          }
-        ],
-        "Body": "{\"order\": \"world\", \"product\":\"world\"}",
-        "Replace": {
-          "RegexUriReplacements": {
-            "order": "orders/([\\w\\d]+)/.+",
-            "product": "/([\\w\\d]+)$"
-          }
-        }
-      }
-    },
-    {
-      "Request": {
-        "Methods": [ "GET" ],
-        "PathStartsWith": "/api/wines"
-      },
-      "Response": {
-        "Status": 200,
-        "Headers": [
-          {
-            "Content-Type": "application/json"
-          }
-        ],
-        "BodyFromFilePath": "./TestData/wine.json",
-        "Replace": {
-          "UriTemplate": "wines/{wine}/{color}",
-          "UriPathReplacements": {
-            "wine": "{wine}", //bodyValue:uriValue
-            "color": "{color}"
-          }
-        }
-      }
-    },
-    {
-      "Request": {
-        "Methods": [ "GET" ],
-        "PathStartsWith": "/api/replace"
-      },
-      "Response": {
-        "Status": 200,
-        "Headers": [
-          {
-            "Content-Type": "application/json"
-          }
-        ],
-        "Body": "{\"replace\": \"original\"}", //more useful when body is from file, to stub different responses shortly
-        "Replace": {
-          "BodyReplacements": {
-            "replace": "modified" //bodyValue:uriValue
-          }
-        }
-      }
-    }
-  ]
+		},
+		{
+			"Request": {
+				"Methods": [ "GET" ],
+				"PathStartsWith": "/api/orders"
+			},
+			"Response": {
+				"Status": 200,
+				"Headers": [
+					{
+						"Content-Type": "application/json"
+					}
+				],
+				"Body": "{\"order\": \"world\", \"product\":\"world\"}",
+				"Replace": {
+					"RegexUriReplacements": {
+						"order": "orders/([\\w\\d]+)/.+",
+						"product": "/([\\w\\d]+)$"
+					}
+				}
+			}
+		},
+		{
+			"Request": {
+				"Methods": [ "GET" ],
+				"PathStartsWith": "/api/wines"
+			},
+			"Response": {
+				"Status": 200,
+				"Headers": [
+					{
+						"Content-Type": "application/json"
+					}
+				],
+				"BodyFromFilePath": "./TestData/wine.json",
+				"Replace": {
+					"UriTemplate": "wines/{wine}/{color}",
+					"UriPathReplacements": {
+						"wine": "{wine}", //bodyValue:uriValue
+						"color": "{color}"
+					}
+				}
+			}
+		},
+		{
+			"Request": {
+				"Methods": [ "GET" ],
+				"PathStartsWith": "/api/replace"
+			},
+			"Response": {
+				"Status": 200,
+				"Headers": [
+					{
+						"Content-Type": "application/json"
+					}
+				],
+				"Body": "{\"replace\": \"original\"}", //more useful when body is from file, to stub different responses shortly
+				"Replace": {
+					"BodyReplacements": {
+						"replace": "modified" //bodyValue:uriValue
+					}
+				}
+			}
+		}
+	]
 }

--- a/KestrelMock/Domain/BodyCheckMapping.cs
+++ b/KestrelMock/Domain/BodyCheckMapping.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace KestrelMock.Domain
 {
-    public sealed class BodyCheckMapping : ConcurrentDictionary<string, List<HttpMockSetting>>
+    public sealed class BodyCheckMapping : ConcurrentDictionary<PathMappingKey, List<HttpMockSetting>>
     {
 
     }

--- a/KestrelMock/Domain/PathMapping.cs
+++ b/KestrelMock/Domain/PathMapping.cs
@@ -3,7 +3,7 @@ using System.Collections.Concurrent;
 
 namespace KestrelMock.Domain
 {
-    public sealed class PathMapping : ConcurrentDictionary<string, HttpMockSetting>
+    public sealed class PathMapping : ConcurrentDictionary<PathMappingKey, HttpMockSetting>
     {
 
     }

--- a/KestrelMock/Domain/PathMappingKey.cs
+++ b/KestrelMock/Domain/PathMappingKey.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+
+namespace KestrelMock.Domain
+{
+    public class PathMappingKey
+    {
+        public string Path { get; set; }
+
+        public string Method { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            return obj is PathMappingKey key &&
+                   Path == key.Path &&
+                   Method == key.Method;
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = -1266948330;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Path);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Method);
+            return hashCode;
+        }
+    }
+}

--- a/KestrelMock/Domain/PathMappingRegexKey.cs
+++ b/KestrelMock/Domain/PathMappingRegexKey.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace KestrelMock.Domain
+{
+    public class PathMappingRegexKey
+    {
+        public Regex Regex { get; set; }
+
+        public string Method { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            return obj is PathMappingRegexKey key &&
+                   EqualityComparer<Regex>.Default.Equals(Regex, key.Regex) &&
+                   Method == key.Method;
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = 1571525928;
+            hashCode = hashCode * -1521134295 + EqualityComparer<Regex>.Default.GetHashCode(Regex);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Method);
+            return hashCode;
+        }
+    }
+}

--- a/KestrelMock/Domain/PathMatchesRegexMapping.cs
+++ b/KestrelMock/Domain/PathMatchesRegexMapping.cs
@@ -4,7 +4,7 @@ using System.Text.RegularExpressions;
 
 namespace KestrelMock.Domain
 {
-    public sealed class PathMatchesRegexMapping : ConcurrentDictionary<Regex, HttpMockSetting>
+    public sealed class PathMatchesRegexMapping : ConcurrentDictionary<PathMappingRegexKey, HttpMockSetting>
     {
 
     }

--- a/KestrelMock/Domain/PathStartsWithMapping.cs
+++ b/KestrelMock/Domain/PathStartsWithMapping.cs
@@ -3,7 +3,7 @@ using System.Collections.Concurrent;
 
 namespace KestrelMock.Domain
 {
-    public sealed class PathStartsWithMapping : ConcurrentDictionary<string, HttpMockSetting>
+    public sealed class PathStartsWithMapping : ConcurrentDictionary<PathMappingKey, HttpMockSetting>
     {
 
     }

--- a/KestrelMock/Services/InputMappingParser.cs
+++ b/KestrelMock/Services/InputMappingParser.cs
@@ -24,33 +24,68 @@ namespace KestrelMock.Services
             {
                 if (!string.IsNullOrEmpty(httpMockSetting.Request.Path))
                 {
-                    if (!string.IsNullOrEmpty(httpMockSetting.Request.BodyContains) 
+                    if (!string.IsNullOrEmpty(httpMockSetting.Request.BodyContains)
                         || !string.IsNullOrEmpty(httpMockSetting.Request.BodyDoesNotContain))
                     {
-                        if (inputMappings.BodyCheckMapping.ContainsKey(httpMockSetting.Request.Path))
+                        foreach (var method in httpMockSetting.Request.Methods)
                         {
-                            var bodyContainesList = inputMappings.BodyCheckMapping[httpMockSetting.Request.Path];
-                            bodyContainesList.Add(httpMockSetting);
-                        }
-                        else
-                        {
-                            inputMappings.BodyCheckMapping.TryAdd(httpMockSetting.Request.Path, 
-                                new List<HttpMockSetting> { httpMockSetting });
+                            var key = new PathMappingKey
+                            {
+                                Path = httpMockSetting.Request.Path,
+                                Method = method,
+                            };
+
+                            if (inputMappings.BodyCheckMapping.ContainsKey(key))
+                            {
+                                var bodyContainesList = inputMappings.BodyCheckMapping[key];
+                                bodyContainesList.Add(httpMockSetting);
+                            }
+                            else
+                            {
+                                inputMappings.BodyCheckMapping.TryAdd(key, new List<HttpMockSetting> { httpMockSetting });
+                            }
                         }
                     }
                     else
                     {
-                        inputMappings.PathMapping.TryAdd(httpMockSetting.Request.Path, httpMockSetting);
+                        foreach (var method in httpMockSetting.Request.Methods)
+                        {
+                            var key = new PathMappingKey
+                            {
+                                Path = httpMockSetting.Request.Path,
+                                Method = method
+                            };
+
+                            inputMappings.PathMapping.TryAdd(key, httpMockSetting);
+                        }
+
                     }
                 }
                 else if (!string.IsNullOrEmpty(httpMockSetting.Request.PathStartsWith))
                 {
-                    inputMappings.PathStartsWithMapping.TryAdd(httpMockSetting.Request.PathStartsWith, httpMockSetting);
+                    foreach (var method in httpMockSetting.Request.Methods)
+                    {
+                        var key = new PathMappingKey
+                        {
+                            Path = httpMockSetting.Request.PathStartsWith,
+                            Method = method
+                        };
+
+                        inputMappings.PathStartsWithMapping.TryAdd(key, httpMockSetting);
+                    }
                 }
                 else if (!string.IsNullOrWhiteSpace(httpMockSetting.Request.PathMatchesRegex))
                 {
-                    var regex = new Regex(httpMockSetting.Request.PathMatchesRegex, RegexOptions.Compiled);
-                    inputMappings.PathMatchesRegexMapping.TryAdd(regex, httpMockSetting);
+                    foreach (var method in httpMockSetting.Request.Methods)
+                    {
+                        var key = new PathMappingRegexKey
+                        {
+                            Regex = new Regex(httpMockSetting.Request.PathMatchesRegex, RegexOptions.Compiled),
+                            Method = method,
+                        };
+
+                        inputMappings.PathMatchesRegexMapping.TryAdd(key, httpMockSetting);
+                    }
                 }
             }
 

--- a/KestrelMock/Services/MockService.cs
+++ b/KestrelMock/Services/MockService.cs
@@ -60,7 +60,9 @@ namespace KestrelMock.Services
                 body = await reader.ReadToEndAsync();
             }
 
-            var matchResult = ResponseMatcher.FindMatchingResponseMock(path, body, mappings);
+            var method = context.Request.Method;
+
+            var matchResult = ResponseMatcher.FindMatchingResponseMock(path, body, method, mappings);
 
             if (matchResult is null)
             {


### PR DESCRIPTION
When building up match data now use the path / regex and methods from configuration.
Also now when checking for matches check to make sure the requested method matches configured mocks.

bug #14