### PR TITLE
Query parameters - issue #28

### DIFF
--- a/KestrelMock.Tests/HelloWorld.cs
+++ b/KestrelMock.Tests/HelloWorld.cs
@@ -1,7 +1,7 @@
 ﻿namespace KestrelMockServer.Tests
 {
-	public class HelloWorld
-	{
-		public string Hello { get; set; }
-	}
+    public class HelloWorld
+    {
+        public string Hello { get; set; }
+    }
 }

--- a/KestrelMock.Tests/KestrelMock.Tests.csproj
+++ b/KestrelMock.Tests/KestrelMock.Tests.csproj
@@ -23,10 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="Moq" Version="4.14.5" />
-    <PackageReference Include="Refit" Version="5.1.67" />
+    <PackageReference Include="Moq" Version="4.14.7" />
+    <PackageReference Include="Refit" Version="5.2.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/KestrelMock.Tests/MockTests.cs
+++ b/KestrelMock.Tests/MockTests.cs
@@ -350,11 +350,11 @@ namespace KestrelMockServer.Tests
                                 Body = "{ \"wine\" : \"123\", \"color\" : \"abcde\" }",
                                 Replace = new Replace
                                 {
-                                    UriTemplate = new UriTemplate(@"/api/wines/{wine}/{color}"),
+                                    UriTemplate = @"/api/wines/{wine}/{color}",
                                     UriPathReplacements = new System.Collections.Generic.Dictionary<string, string>
                                     {
-                                        { "wine", wine },
-                                        { "color", color }
+                                        { "wine", "{wine}" },
+                                        { "color", "{color}"}
                                     }
                                 }
                             }
@@ -403,12 +403,12 @@ namespace KestrelMockServer.Tests
                                 Body = "{ \"wine\" : \"123\", \"color\" : \"abcde\", \"year\":\"0\" }",
                                 Replace = new Replace
                                 {
-                                    UriTemplate = new UriTemplate(@"/api/wines/{wine}/{color}?year={year}"),
+                                    UriTemplate = @"/api/wines/{wine}/{color}?year={year}",
                                     UriPathReplacements = new System.Collections.Generic.Dictionary<string, string>
                                     {
-                                        { "wine", wine },
-                                        { "color", color },
-                                        { "year", "1978" }
+                                        { "wine", "{wine}" },
+                                        { "color", "{color}" },
+                                        { "year", "{year}" }
                                     }
                                 }
                             }
@@ -461,7 +461,7 @@ namespace KestrelMockServer.Tests
                                 " }",
                                 Replace = new Replace
                                 {
-                                    UriTemplate = new UriTemplate(@"/api/wines/{wine}/{color}?year={year}"),
+                                    UriTemplate = @"/api/wines/{wine}/{color}?year={year}",
                                     UriPathReplacements = new System.Collections.Generic.Dictionary<string, string>
                                     {
                                         { "wine", wine },
@@ -517,7 +517,7 @@ namespace KestrelMockServer.Tests
                                 Body = "{ \"wine\" : \"123\", \"color\" : \"abcde\", \"year\":0 }",
                                 Replace = new Replace
                                 {
-                                    UriTemplate = new UriTemplate(@"/api/wines/{wine}/{color}?year={year}"),
+                                    UriTemplate = @"/api/wines/{wine}/{color}?year={year}",
                                     UriPathReplacements = new System.Collections.Generic.Dictionary<string, string>
                                     {
                                         { "wine", wine },

--- a/KestrelMock.Tests/MockTests.cs
+++ b/KestrelMock.Tests/MockTests.cs
@@ -323,7 +323,7 @@ namespace KestrelMockServer.Tests
 
         [Theory]
         [InlineData("CHIANTI", "RED", ""),
-        InlineData("CHIANTI", "RED", "?text=2")]
+        InlineData("CHIANTI", "RED", "?year=1978")]
         public async Task CanReplaceBodyFromUriWithUriParameters(string wine, string color, string extraQuery)
         {
             var client = _factory.WithWebHostBuilder(b =>
@@ -373,6 +373,10 @@ namespace KestrelMockServer.Tests
 
             Assert.Contains($"\"wine\":\"{wine}\"", body);
             Assert.Contains($"\"color\":\"{color}\"", body);
+            if (!String.IsNullOrWhiteSpace(extraQuery))
+            {
+                Assert.Contains($"\"year\":\"1978\"", body);
+            }
             Assert.Equal(200, (int)response.StatusCode);
         }
 

--- a/KestrelMock.Tests/MockTests.cs
+++ b/KestrelMock.Tests/MockTests.cs
@@ -324,7 +324,7 @@ namespace KestrelMockServer.Tests
         [Theory]
         [InlineData("CHIANTI", "RED", ""),
         InlineData("CHIANTI", "RED", "?year=1978")]
-        public async Task CanReplaceBodyFromUriWithUriParameters(string wine, string color, string extraQuery)
+        public async Task CanReplaceBodyFromUriParameters(string wine, string color, string extraQuery)
         {
             var client = _factory.WithWebHostBuilder(b =>
             {
@@ -348,11 +348,10 @@ namespace KestrelMockServer.Tests
                             {
                                 Status = 200,
                                 Body = "{ \"wine\" : \"123\", \"color\" : \"abcde\" }",
-                                //TODO: noted bug, replacement does not work correctly for numbers in json
                                 Replace = new Replace
                                 {
-                                    UriTemplate = @"/api/wines/{wine}/{color}",
-                                    BodyReplacements = new System.Collections.Generic.Dictionary<string, string>
+                                    UriTemplate = new UriTemplate(@"/api/wines/{wine}/{color}"),
+                                    UriPathReplacements = new System.Collections.Generic.Dictionary<string, string>
                                     {
                                         { "wine", wine },
                                         { "color", color }
@@ -373,12 +372,179 @@ namespace KestrelMockServer.Tests
 
             Assert.Contains($"\"wine\":\"{wine}\"", body);
             Assert.Contains($"\"color\":\"{color}\"", body);
-            if (!String.IsNullOrWhiteSpace(extraQuery))
-            {
-                Assert.Contains($"\"year\":\"1978\"", body);
-            }
             Assert.Equal(200, (int)response.StatusCode);
         }
+
+        [Theory]
+        [InlineData("CHIANTI", "RED", "?year=1978")]
+        public async Task CanReplaceBodyFromUriWithQuery(string wine, string color, string extraQuery)
+        {
+            var client = _factory.WithWebHostBuilder(b =>
+            {
+                b.ConfigureTestServices(services =>
+                {
+
+                    services.Configure((Action<MockConfiguration>)(opts =>
+                    {
+                        opts.Clear();
+                        var setting = new HttpMockSetting
+                        {
+                            Request = new Request
+                            {
+                                Methods = new System.Collections.Generic.List<string>
+                                {
+                                    "GET"
+                                },
+                                PathStartsWith = "/api/wines/"
+                            },
+                            Response = new Response
+                            {
+                                Status = 200,
+                                Body = "{ \"wine\" : \"123\", \"color\" : \"abcde\", \"year\":\"0\" }",
+                                Replace = new Replace
+                                {
+                                    UriTemplate = new UriTemplate(@"/api/wines/{wine}/{color}?year={year}"),
+                                    UriPathReplacements = new System.Collections.Generic.Dictionary<string, string>
+                                    {
+                                        { "wine", wine },
+                                        { "color", color },
+                                        { "year", "1978" }
+                                    }
+                                }
+                            }
+                        };
+
+                        opts.Add(setting);
+                    }));
+
+                });
+            }).CreateClient();
+
+            var response = await client.GetAsync($"/api/wines/{wine}/{color}{extraQuery}");
+
+            var body = await response.Content.ReadAsStringAsync();
+
+            Assert.Contains($"\"wine\":\"{wine}\"", body);
+            Assert.Contains($"\"color\":\"{color}\"", body);
+            Assert.Contains($"\"year\":\"1978\"", body);
+            
+            Assert.Equal(200, (int)response.StatusCode);
+        }
+
+        [Theory]
+        [InlineData("CHIANTI", "RED", "?doesnt=matter")]
+        public async Task CanReplaceBodyWhenMultiple(string wine, string color, string extraQuery)
+        {
+            var client = _factory.WithWebHostBuilder(b =>
+            {
+                b.ConfigureTestServices(services =>
+                {
+
+                    services.Configure((Action<MockConfiguration>)(opts =>
+                    {
+                        opts.Clear();
+                        var setting = new HttpMockSetting
+                        {
+                            Request = new Request
+                            {
+                                Methods = new System.Collections.Generic.List<string>
+                                {
+                                    "GET"
+                                },
+                                PathStartsWith = "/api/wines/"
+                            },
+                            Response = new Response
+                            {
+                                Status = 200,
+                                Body = "{ \"wine\" : \"123\", \"color\" : \"abcde\", \"year\": 1978," +
+                                " \"nested\" : { \"color\" : \"x\" }" +
+                                " }",
+                                Replace = new Replace
+                                {
+                                    UriTemplate = new UriTemplate(@"/api/wines/{wine}/{color}?year={year}"),
+                                    UriPathReplacements = new System.Collections.Generic.Dictionary<string, string>
+                                    {
+                                        { "wine", wine },
+                                        { "color", color }
+                                    }
+                                }
+                            }
+                        };
+
+                        opts.Add(setting);
+                    }));
+
+                });
+            }).CreateClient();
+
+            var response = await client.GetAsync($"/api/wines/{wine}/{color}{extraQuery}");
+
+            var body = await response.Content.ReadAsStringAsync();
+
+            Assert.Contains($"\"wine\":\"{wine}\"", body);
+            Assert.Contains($", \"color\":\"{color}\"", body);
+            Assert.Contains($"{{ \"color\":\"{color}\"", body);
+            
+            Assert.Equal(200, (int)response.StatusCode);
+        }
+
+
+        [Theory]
+        [InlineData("CHIANTI", "RED", "?year=1978")]
+        public async Task CanReplaceFromUriNumbersInBody(string wine, string color, string extraQuery)
+        {
+            var client = _factory.WithWebHostBuilder(b =>
+            {
+                b.ConfigureTestServices(services =>
+                {
+
+                    services.Configure((Action<MockConfiguration>)(opts =>
+                    {
+                        opts.Clear();
+                        var setting = new HttpMockSetting
+                        {
+                            Request = new Request
+                            {
+                                Methods = new System.Collections.Generic.List<string>
+                                {
+                                    "GET"
+                                },
+                                PathStartsWith = "/api/wines/"
+                            },
+                            Response = new Response
+                            {
+                                Status = 200,
+                                Body = "{ \"wine\" : \"123\", \"color\" : \"abcde\", \"year\":0 }",
+                                Replace = new Replace
+                                {
+                                    UriTemplate = new UriTemplate(@"/api/wines/{wine}/{color}?year={year}"),
+                                    UriPathReplacements = new System.Collections.Generic.Dictionary<string, string>
+                                    {
+                                        { "wine", wine },
+                                        { "color", color },
+                                        { "year", "1978" }
+                                    }
+                                }
+                            }
+                        };
+
+                        opts.Add(setting);
+                    }));
+
+                });
+            }).CreateClient();
+
+            var response = await client.GetAsync($"/api/wines/{wine}/{color}{extraQuery}");
+
+            var body = await response.Content.ReadAsStringAsync();
+
+            Assert.Contains($"\"wine\":\"{wine}\"", body);
+            Assert.Contains($"\"color\":\"{color}\"", body);
+            Assert.Contains($"\"year\":1978", body);
+
+            Assert.Equal(200, (int)response.StatusCode);
+        }
+
 
         [Fact]
         public async Task CanReplaceBodySingleFieldFromSettings()
@@ -427,7 +593,6 @@ namespace KestrelMockServer.Tests
             Assert.Equal($"{{ \"replace\":\"modified\" }}", await response.Content.ReadAsStringAsync());
             Assert.Equal(200, (int)response.StatusCode);
         }
-
 
         [Fact]
         public async Task LoadBodyFromRelativePath()

--- a/KestrelMock.Tests/UriPathReplaceServiceTests.cs
+++ b/KestrelMock.Tests/UriPathReplaceServiceTests.cs
@@ -1,0 +1,50 @@
+﻿using KestrelMockServer.Services;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace KestrelMockServer.Tests
+{
+    public class UriPathReplaceServiceTests
+    {
+        private readonly UriPathReplaceService service;
+
+        public UriPathReplaceServiceTests()
+        {
+            service = new UriPathReplaceService();
+        }
+
+        [Theory,
+            InlineData("api/test/{one}?two={two}", 
+                "api/test/1?two=2", "one:{one}", "two:{two}"),
+            InlineData("api/test/{one}?two={two}", 
+                "api/test/1", "one:{one}", "two:2"),
+            InlineData("api/test/{one}?two={two}", 
+                "api/test/1?whatever=x", "one:{one}", "two:2"),
+            InlineData("api/test/{one}?two={two}&three={three}", 
+                "api/test/1?whatever=x&two=2", "one:{one}", "two:{two}", "three:{three}")]
+        public void ReplaceOk(string uriTemplate, string pathAndQuery, params string[] replacements)
+        {
+            var body = @"{""one"": 0, ""two"":""a"", ""three"":""hello""}";
+
+            var uriReplacements = replacements.ToDictionary(s => s.Split(":")[0],
+                s => s.Split(":")[1]);
+
+            var finalBody = service.UriPathReplacements(pathAndQuery, new Settings.Response
+            {
+                Body = body,
+                Replace =
+                new Settings.Replace{
+                    UriPathReplacements = uriReplacements,
+                    UriTemplate = uriTemplate
+                }
+            }, body);
+
+            var expectedBody = @"{""one"":1, ""two"":""2"", ""three"":""hello""}";
+
+            Assert.Equal(expectedBody, finalBody);
+        }
+
+
+    }
+}

--- a/KestrelMock.Tests/UriTemplateTests.cs
+++ b/KestrelMock.Tests/UriTemplateTests.cs
@@ -21,5 +21,35 @@ namespace KestrelMockServer.Tests
             Assert.Equal("something", result["test"]);
             Assert.Equal("y", result["x"]);
         }
+
+        [Theory,
+            InlineData("/{name}/{surname}/x/{test}?query={query}",
+                "/john/reds/x/something?query=hello&x=y")
+        ]
+        public void UriTemplate_MatchesIncomingPathWithExtraParameters_Ok(string template, string path)
+        {
+            var x = new UriTemplate(template);
+
+            var result = x.Parse(path);
+            Assert.Equal("john", result["name"]);
+            Assert.Equal("hello", result["query"]);
+            Assert.Equal("reds", result["surname"]);
+            Assert.Equal("something", result["test"]);
+        }
+
+        [Theory,
+            InlineData("/{name}/{surname}/x/{test}?query={query}",
+                "/john/reds/x/something?x=y&query=hello")
+        ]
+        public void UriTemplate_MatchesWithInvertedQueryParameters_Ok(string template, string path)
+        {
+            var x = new UriTemplate(template);
+
+            var result = x.Parse(path);
+            Assert.Equal("john", result["name"]);
+            Assert.Equal("hello", result["query"]);
+            Assert.Equal("reds", result["surname"]);
+            Assert.Equal("something", result["test"]);
+        }
     }
 }

--- a/KestrelMock.Tests/UriTemplateTests.cs
+++ b/KestrelMock.Tests/UriTemplateTests.cs
@@ -23,6 +23,20 @@ namespace KestrelMockServer.Tests
         }
 
         [Theory,
+            InlineData("/{name}/{surname}/x/{test}", "/john/reds/x/something?query=hello&x=y"),
+            InlineData("/{name}/{surname}/x/{test}", "/john/reds/x/something")
+        ]
+        public void UriTemplate_MatchesWithoutQuery_Ok(string template, string path)
+        {
+            var x = new UriTemplate(template);
+
+            var result = x.Parse(path);
+            Assert.Equal("john", result["name"]);
+            Assert.Equal("reds", result["surname"]);
+            Assert.Equal("something", result["test"]);
+        }
+
+        [Theory,
             InlineData("/{name}/{surname}/x/{test}?query={query}",
                 "/john/reds/x/something?query=hello&x=y")
         ]

--- a/KestrelMock.Tests/UriTemplateTests.cs
+++ b/KestrelMock.Tests/UriTemplateTests.cs
@@ -1,0 +1,25 @@
+﻿using KestrelMockServer.Settings;
+using Xunit;
+
+namespace KestrelMockServer.Tests
+{
+    public class UriTemplateTests
+    {
+
+        [Theory, 
+            InlineData("/{name}/{surname}/x/{test}?query={query}&x={x}", 
+                "/john/reds/x/something?query=hello&x=y")
+        ]
+        public void UriTemplate_MatchesIncomingPathWithQuery_Ok(string template, string path)
+        {
+            var x = new UriTemplate(template);
+
+            var result = x.Parse(path);
+            Assert.Equal("john", result["name"]);
+            Assert.Equal("hello", result["query"]);
+            Assert.Equal("reds", result["surname"]);
+            Assert.Equal("something", result["test"]);
+            Assert.Equal("y", result["x"]);
+        }
+    }
+}

--- a/KestrelMock/Services/BodyRewriterService.cs
+++ b/KestrelMock/Services/BodyRewriterService.cs
@@ -1,0 +1,22 @@
+﻿using System.Text.RegularExpressions;
+
+namespace KestrelMockServer.Services
+{
+    public static class BodyRewriterService
+    {
+        public static string RegexBodyRewrite(this string input, string propertyName, string replacement)
+        {
+            var regex = $"\"{propertyName}\"\\s*:\\s*(?<value>\".+?\")";
+            var finalReplacement = $"\"{propertyName}\":\"{replacement}\"";
+            var resultBody = Regex.Replace(input, regex, $"{finalReplacement}", RegexOptions.Multiline);
+
+            //replaces numbers
+            var numbersRegex = $"\"{propertyName}\"\\s*:\\s*(?<value>\\d+(.\\d+)?)";
+            var numberFinalReplacement = $"\"{propertyName}\":{replacement}";
+            var finalBody = Regex.Replace(resultBody, numbersRegex, $"{numberFinalReplacement}", RegexOptions.Multiline);
+
+            return finalBody;
+        }
+    }
+
+}

--- a/KestrelMock/Services/BodyWriterService.cs
+++ b/KestrelMock/Services/BodyWriterService.cs
@@ -29,7 +29,7 @@ namespace KestrelMockServer.Services
             {
                 foreach (var keyVal in matchResult.Replace.BodyReplacements)
                 {
-                    resultBody = BodyWriterService.RegexBodyRewrite(resultBody, keyVal.Key, keyVal.Value);
+                    resultBody = resultBody.RegexBodyRewrite(keyVal.Key, keyVal.Value);
                 }
             }
 
@@ -51,19 +51,10 @@ namespace KestrelMockServer.Services
                 var replacement = pathRegexMatch.Groups.Count == 2 ?
                     pathRegexMatch.Groups[1].Value : pathRegexMatch.Value;
 
-                resultBody = RegexBodyRewrite(resultBody, keyVal.Key, replacement);
+                resultBody = resultBody.RegexBodyRewrite(keyVal.Key, replacement);
             }
 
             return resultBody;
-        }
-
-        private static string RegexBodyRewrite(string input, string propertyName, string replacement)
-        {
-            var regex = $"\"{propertyName}\"\\s*:\\s*\"(?<value>.+?)\"";
-
-            var finalReplacement = $"\"{propertyName}\":\"{replacement}\"";
-
-            return Regex.Replace(input, regex, $"{finalReplacement}");
         }
     }
 

--- a/KestrelMock/Services/BodyWriterService.cs
+++ b/KestrelMock/Services/BodyWriterService.cs
@@ -1,5 +1,4 @@
 ﻿using KestrelMockServer.Settings;
-using Microsoft.AspNetCore.Server.Kestrel.Core.Features;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;

--- a/KestrelMock/Services/IUriPathReplaceService.cs
+++ b/KestrelMock/Services/IUriPathReplaceService.cs
@@ -1,0 +1,9 @@
+﻿using KestrelMockServer.Settings;
+
+namespace KestrelMockServer.Services
+{
+    public interface IUriPathReplaceService
+    {
+        string UriPathReplacements(string path, Response matchResult, string resultBody);
+    }
+}

--- a/KestrelMock/Services/UriPathReplaceService.cs
+++ b/KestrelMock/Services/UriPathReplaceService.cs
@@ -1,5 +1,4 @@
 ﻿using KestrelMockServer.Settings;
-using System.Text.RegularExpressions;
 
 namespace KestrelMockServer.Services
 {
@@ -15,24 +14,10 @@ namespace KestrelMockServer.Services
                     matchesOnUri[keyVal.Value] : 
                     keyVal.Value;
 
-                resultBody = RegexBodyRewrite(resultBody, keyVal.Key, valueToReplace);
+                resultBody = resultBody.RegexBodyRewrite(keyVal.Key, valueToReplace);
             }
 
             return resultBody;
-        }
-
-        private static string RegexBodyRewrite(string input, string propertyName, string replacement)
-        {
-            var regex = $"\"{propertyName}\"\\s*:\\s*(?<value>\".+?\")";
-            var finalReplacement = $"\"{propertyName}\":\"{replacement}\"";
-            var resultBody = Regex.Replace(input, regex, $"{finalReplacement}", RegexOptions.Multiline);
-
-            //replaces numbers
-            var numbersRegex = $"\"{propertyName}\"\\s*:\\s*(?<value>\\d+(.\\d+)?)";
-            var numberFinalReplacement = $"\"{propertyName}\":{replacement}";
-            var finalBody = Regex.Replace(resultBody, numbersRegex, $"{numberFinalReplacement}", RegexOptions.Multiline);
-
-            return finalBody;
         }
     }
 

--- a/KestrelMock/Services/UriPathReplaceService.cs
+++ b/KestrelMock/Services/UriPathReplaceService.cs
@@ -1,4 +1,5 @@
 ﻿using KestrelMockServer.Settings;
+using System.Collections.Generic;
 
 namespace KestrelMockServer.Services
 {
@@ -13,15 +14,26 @@ namespace KestrelMockServer.Services
                 var key = replacement.Value
                     .Replace("{", string.Empty)
                     .Replace("}", string.Empty);
-                
-                var valueToReplace = matchesOnUri.ContainsKey(key) ? 
-                    matchesOnUri[key] : 
-                    replacement.Value;
+
+                var valueToReplace =
+                    HasMatch(matchesOnUri, key) ?
+                    matchesOnUri[key] : replacement.Value;
+
+                if (valueToReplace == ($"{{{key}}}"))
+                {
+                    // no match for uri path or string
+                    continue;
+                }
 
                 resultBody = resultBody.RegexBodyRewrite(replacement.Key, valueToReplace);
             }
 
             return resultBody;
+        }
+
+        private static bool HasMatch(IDictionary<string, string> matchesOnUri, string key)
+        {
+            return matchesOnUri.ContainsKey(key) && !string.IsNullOrWhiteSpace(matchesOnUri[key]);
         }
     }
 

--- a/KestrelMock/Services/UriPathReplaceService.cs
+++ b/KestrelMock/Services/UriPathReplaceService.cs
@@ -1,0 +1,39 @@
+﻿using KestrelMockServer.Settings;
+using System.Text.RegularExpressions;
+
+namespace KestrelMockServer.Services
+{
+    public class UriPathReplaceService : IUriPathReplaceService
+    {
+        public string UriPathReplacements(string path, Response matchResult, string resultBody)
+        {
+            var matchesOnUri = matchResult.Replace.UriTemplate.Parse(path);
+
+            foreach (var keyVal in matchResult.Replace.UriPathReplacements)
+            {
+                var valueToReplace = matchesOnUri.ContainsKey(keyVal.Value) ? 
+                    matchesOnUri[keyVal.Value] : 
+                    keyVal.Value;
+
+                resultBody = RegexBodyRewrite(resultBody, keyVal.Key, valueToReplace);
+            }
+
+            return resultBody;
+        }
+
+        private static string RegexBodyRewrite(string input, string propertyName, string replacement)
+        {
+            var regex = $"\"{propertyName}\"\\s*:\\s*(?<value>\".+?\")";
+            var finalReplacement = $"\"{propertyName}\":\"{replacement}\"";
+            var resultBody = Regex.Replace(input, regex, $"{finalReplacement}", RegexOptions.Multiline);
+
+            //replaces numbers
+            var numbersRegex = $"\"{propertyName}\"\\s*:\\s*(?<value>\\d+(.\\d+)?)";
+            var numberFinalReplacement = $"\"{propertyName}\":{replacement}";
+            var finalBody = Regex.Replace(resultBody, numbersRegex, $"{numberFinalReplacement}", RegexOptions.Multiline);
+
+            return finalBody;
+        }
+    }
+
+}

--- a/KestrelMock/Services/UriPathReplaceService.cs
+++ b/KestrelMock/Services/UriPathReplaceService.cs
@@ -6,7 +6,7 @@ namespace KestrelMockServer.Services
     {
         public string UriPathReplacements(string path, Response matchResult, string resultBody)
         {
-            var matchesOnUri = matchResult.Replace.UriTemplate.Parse(path);
+            var matchesOnUri = new UriTemplate(matchResult.Replace.UriTemplate).Parse(path);
 
             foreach (var keyVal in matchResult.Replace.UriPathReplacements)
             {

--- a/KestrelMock/Services/UriPathReplaceService.cs
+++ b/KestrelMock/Services/UriPathReplaceService.cs
@@ -8,13 +8,17 @@ namespace KestrelMockServer.Services
         {
             var matchesOnUri = new UriTemplate(matchResult.Replace.UriTemplate).Parse(path);
 
-            foreach (var keyVal in matchResult.Replace.UriPathReplacements)
+            foreach (var replacement in matchResult.Replace.UriPathReplacements)
             {
-                var valueToReplace = matchesOnUri.ContainsKey(keyVal.Value) ? 
-                    matchesOnUri[keyVal.Value] : 
-                    keyVal.Value;
+                var key = replacement.Value
+                    .Replace("{", string.Empty)
+                    .Replace("}", string.Empty);
+                
+                var valueToReplace = matchesOnUri.ContainsKey(key) ? 
+                    matchesOnUri[key] : 
+                    replacement.Value;
 
-                resultBody = resultBody.RegexBodyRewrite(keyVal.Key, valueToReplace);
+                resultBody = resultBody.RegexBodyRewrite(replacement.Key, valueToReplace);
             }
 
             return resultBody;

--- a/KestrelMock/Settings/Replace.cs
+++ b/KestrelMock/Settings/Replace.cs
@@ -4,7 +4,7 @@ namespace KestrelMockServer.Settings
 {
     public class Replace
     {
-		public UriTemplate UriTemplate { get; set; }
+		public string UriTemplate { get; set; }
 		public Dictionary<string, string> BodyReplacements { get; set; }
 		public Dictionary<string, string> UriPathReplacements { get; set; }
 		public Dictionary<string, string> RegexUriReplacements { get; set; }

--- a/KestrelMock/Settings/Replace.cs
+++ b/KestrelMock/Settings/Replace.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace KestrelMockServer.Settings
 {
     public class Replace
     {
-		public string UriTemplate { get; set; }
+		public UriTemplate UriTemplate { get; set; }
 		public Dictionary<string, string> BodyReplacements { get; set; }
 		public Dictionary<string, string> UriPathReplacements { get; set; }
 		public Dictionary<string, string> RegexUriReplacements { get; set; }

--- a/KestrelMock/Settings/UriTemplate.cs
+++ b/KestrelMock/Settings/UriTemplate.cs
@@ -34,6 +34,7 @@ namespace KestrelMockServer.Settings
 
         public IDictionary<string, string> Parse(string inputPath)
         {
+            //TODO: make query parameter match optional (and simplify logic)
             string parameterRegexString = PathAndQuery
                .Replace("/", @"\/")
                .Replace("?", @"\?"); //for query prameters

--- a/KestrelMock/Settings/UriTemplate.cs
+++ b/KestrelMock/Settings/UriTemplate.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+namespace KestrelMockServer.Settings
+{
+    public class UriTemplate
+    {
+        private readonly Uri uri;
+
+        public string PathAndQuery { get; }
+        public string Path { get; }
+        public string Query { get; }
+        public NameValueCollection QueryParameters { get; }
+
+        private readonly List<string> parameters;
+
+        private static readonly Regex ParameterRegex = 
+            new Regex(
+                @"\{(?<parameter>[^{}?]*)\}", 
+                RegexOptions.Compiled);
+
+        public UriTemplate(string uriTemplate)
+        {
+            uri = new Uri(new Uri("http://localhost"), uriTemplate);
+            PathAndQuery = Uri.UnescapeDataString(uri.PathAndQuery);
+            Path = Uri.UnescapeDataString(uri.AbsolutePath);
+            Query = Uri.UnescapeDataString(uri.Query);
+            QueryParameters = System.Web.HttpUtility.ParseQueryString(uri.Query);
+            parameters = new List<string>();
+        }
+
+        public IDictionary<string, string> Parse(string inputPath)
+        {
+            string parameterRegexString = PathAndQuery
+               .Replace("/", @"\/")
+               .Replace("?", @"\?"); //for query prameters
+
+            foreach (Match match in ParameterRegex.Matches(PathAndQuery))
+            {
+                var parameterName = match.Groups["parameter"].Value;
+                parameters.Add(parameterName);
+
+                parameterRegexString = 
+                    parameterRegexString
+                    .Replace(match.Value, 
+                    $"(?<{parameterName}>[^{{}}?]*)");
+            }
+
+            if (!PathAndQuery.Contains("?"))
+            {
+                //accept any optional parameter string (don't care)
+                parameterRegexString = $"{parameterRegexString}\\??";
+            }
+
+            parameterRegexString = $"{parameterRegexString}.*";
+
+            var matches = Regex.Match(inputPath, parameterRegexString);
+
+            var result = new Dictionary<string, string>();
+
+            foreach(var parameter in parameters)
+            {
+                result.Add(parameter, matches.Groups[parameter].Value);
+            }
+
+            return result;
+        }
+    }
+}

--- a/KestrelMock/Startup.cs
+++ b/KestrelMock/Startup.cs
@@ -34,6 +34,7 @@ namespace KestrelMockServer
             services.AddTransient<IBodyWriterService, BodyWriterService>();
             services.AddTransient<IResponseMatcherService, ResponseMatcherService>();
 			services.AddTransient<IInputMappingParser, InputMappingParser>();
+            services.AddTransient<IUriPathReplaceService, UriPathReplaceService>();
             services.Configure<MockConfiguration>(configuration.GetSection("MockSettings"));
 		}
 

--- a/KestrelMockServer/Properties/launchSettings.json
+++ b/KestrelMockServer/Properties/launchSettings.json
@@ -34,7 +34,7 @@
       //"sslPort": 44360,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        //"ASPNETCORE_URLS": "http://127.0.0.1:80",
+        "ASPNETCORE_URLS": "http://*:80"
         //"ASPNETCORE_Kestrel__Certificates__Default__Path": "/https/aspnetapp.pfx"
       }
     }

--- a/KestrelMockServer/Properties/launchSettings.json
+++ b/KestrelMockServer/Properties/launchSettings.json
@@ -12,7 +12,8 @@
       "commandName": "IISExpress",
       "launchBrowser": true,
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_URLS": "http://localhost:5000"
       }
     },
     "KestrelMockServer": {

--- a/KestrelMockServer/appsettings.json
+++ b/KestrelMockServer/appsettings.json
@@ -5,6 +5,23 @@
         "Methods": [
           "GET"
         ],
+        "Path": "/"
+      },
+      "Response": {
+        "Status": 200,
+        "Headers": [
+          {
+            "Content-Type": "application/json"
+          }
+        ],
+        "Body": "Welcome to MockServer"
+      }
+    },
+    {
+      "Request": {
+        "Methods": [
+          "GET"
+        ],
         "PathStartsWith": "/starts/with"
       },
       "Response": {
@@ -68,13 +85,13 @@
             "Content-Type": "application/json"
           }
         ],
-        //"Body" : "{\"wine\":\"red\",\"color\":\"blue\"}",
         "BodyFromFilePath": "./responses/wine.json",
         "Replace": {
-          "UriTemplate": "wines/{wine}/{color}",
+          "UriTemplate": "wines/{wine}/{color}?year={year}",
           "UriPathReplacements": {
-            "wine": "{wine}", //bodyValue:uriValue
-            "color": "{color}"
+            "wine": "{wine}",
+            "color": "{color}",
+            "year": "{year}"
           }
         }
       }


### PR DESCRIPTION
* adds supports to read **query** parameters from URI to re-write body
* adds supports to json **numbers** in body rewrite (previously only string workes)
* **multi-line** replacement in body (now tested)
* extracted a small utility class UriTemplate

this should be very useful :) fixes #28  

Let me know @JasonRowe , have a nice sunday!

```
/ http://localhost:5000/api/wines/CHIANTI/RED?year=1984

{
  "wine": "CHIANTI",
  "description": {
    "color": "RED",
    "year": 1984 <<<<<
  }
}
```