### PR TITLE
Add new RunAsync to make it easier for simple testing

### DIFF
--- a/KestrelMock.Tests/MockTests.cs
+++ b/KestrelMock.Tests/MockTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -33,6 +34,15 @@ namespace KestrelMockServer.Tests
             {
                 Assert.Contains("Configuration must include 'MockSettings' section", ex.Message);
             }
+        }
+
+        [Fact]
+        public void RunAsyncReturns()
+        {
+            var builder = new ConfigurationBuilder().AddJsonFile($"appsettings.json", optional: false);
+            var configuration = builder.Build();
+            var runAsyncResult = KestrelMock.RunAsync(configuration);
+            Assert.NotNull(runAsyncResult);
         }
 
         private readonly MockTestApplicationFactory _factory;

--- a/KestrelMock/KestrelMock.csproj
+++ b/KestrelMock/KestrelMock.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<PackageId>KestrelMock</PackageId>
-		<PackageVersion>0.2.0</PackageVersion>
+		<PackageVersion>0.3.0</PackageVersion>
 		<Authors>Jason Rowe</Authors>
 		<Description>.Net Core HTTP mocking server</Description>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/KestrelMock/Startup.cs
+++ b/KestrelMock/Startup.cs
@@ -1,46 +1,35 @@
-﻿using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net.Http.Headers;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
-using KestrelMockServer.Services;
+﻿using KestrelMockServer.Services;
 using KestrelMockServer.Settings;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 
 namespace KestrelMockServer
 {
-	/// <summary>
-	/// default startup implementation, this should not be necessary for aspnetcore.. might simplify a bit
-	/// </summary>
-	public class Startup
-	{
-		private readonly IConfiguration configuration;
+    /// <summary>
+    /// default startup implementation, this should not be necessary for aspnetcore.. might simplify a bit
+    /// </summary>
+    public class Startup
+    {
+        private readonly IConfiguration configuration;
 
-		public Startup(IConfiguration configuration)
-		{
-			this.configuration = configuration;
-		}
+        public Startup(IConfiguration configuration)
+        {
+            this.configuration = configuration;
+        }
 
-		public void ConfigureServices(IServiceCollection services)
-		{
+        public void ConfigureServices(IServiceCollection services)
+        {
             services.AddTransient<IBodyWriterService, BodyWriterService>();
             services.AddTransient<IResponseMatcherService, ResponseMatcherService>();
-			services.AddTransient<IInputMappingParser, InputMappingParser>();
+            services.AddTransient<IInputMappingParser, InputMappingParser>();
             services.AddTransient<IUriPathReplaceService, UriPathReplaceService>();
             services.Configure<MockConfiguration>(configuration.GetSection("MockSettings"));
-		}
+        }
 
-		public void Configure(IApplicationBuilder app)
-		{
+        public void Configure(IApplicationBuilder app)
+        {
             app.UseMiddleware<MockService>();
         }
-	}
+    }
 }


### PR DESCRIPTION
Create a RunAsync method which can be used to startup the server and use it directly from a test
project.

fixes #26