### PR TITLE
New endpoint to create, delete, and view mocks

### DIFF
--- a/KestrelMock/KestrelMock.csproj
+++ b/KestrelMock/KestrelMock.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<PackageId>KestrelMock</PackageId>
-		<PackageVersion>0.3.0</PackageVersion>
+		<PackageVersion>0.4.0</PackageVersion>
 		<Authors>Jason Rowe</Authors>
 		<Description>.Net Core HTTP mocking server</Description>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/KestrelMock/Services/MockService.cs
+++ b/KestrelMock/Services/MockService.cs
@@ -41,7 +41,7 @@ namespace KestrelMockServer.Services
             {
                 if (context.Request.Path.StartsWithSegments(new PathString("/kestrelmock/mocks")))
                 {
-                    await InvokeAdminApi(context, _inputMappingParser);
+                    await InvokeAdminApi(context);
                 }
                 else
                 {
@@ -117,7 +117,7 @@ namespace KestrelMockServer.Services
             return true;
         }
 
-        protected async Task<bool> InvokeAdminApi(HttpContext context, IInputMappingParser inputMappingParser)
+        protected async Task<bool> InvokeAdminApi(HttpContext context)
         {
 
             if (context.Request.Method == HttpMethods.Get)

--- a/KestrelMock/Settings/HttpMockSetting.cs
+++ b/KestrelMock/Settings/HttpMockSetting.cs
@@ -1,11 +1,11 @@
-﻿using KestrelMockServer.Domain;
-
-namespace KestrelMockServer.Settings
+﻿namespace KestrelMockServer.Settings
 {
-	public class HttpMockSetting
-	{
-		public Request Request { get; set; }
+    public class HttpMockSetting
+    {
+        public string Id { get; set; }
 
-		public Response Response { get; set; }
-	}
+        public Request Request { get; set; }
+
+        public Response Response { get; set; }
+    }
 }

--- a/KestrelMockServer/appsettings.json
+++ b/KestrelMockServer/appsettings.json
@@ -1,100 +1,105 @@
 ﻿{
-  "MockSettings": [
-    {
-      "Request": {
-        "Methods": [
-          "GET"
-        ],
-        "Path": "/"
-      },
-      "Response": {
-        "Status": 200,
-        "Headers": [
-          {
-            "Content-Type": "application/json"
-          }
-        ],
-        "Body": "Welcome to MockServer"
-      }
-    },
-    {
-      "Request": {
-        "Methods": [
-          "GET"
-        ],
-        "PathStartsWith": "/starts/with"
-      },
-      "Response": {
-        "Status": 200,
-        "Headers": [
-          {
-            "Content-Type": "application/json"
-          }
-        ],
-        "Body": "{\"hello\":\"world\"}"
-      }
-    },
-    {
-      "Request": {
-        "Methods": [
-          "GET"
-        ],
-        "PathMatchesRegex": "/\\d+"
-      },
-      "Response": {
-        "Status": 200,
-        "Headers": [
-          {
-            "Content-Type": "application/json"
-          }
-        ],
-        "Body": null,
-        "BodyFromFilePath": "./responses/response.json"
-      }
-    },
-    {
-      "Request": {
-        "Methods": [ "GET" ],
-        "PathStartsWith": "/api/cars"
-      },
-      "Response": {
-        "Status": 200,
-        "Headers": [
-          {
-            "Content-Type": "application/json"
-          }
-        ],
-        "Body": "{\"car\": \"ORDER-X\", \"color\": \"product-y\"}",
-        "Replace": {
-          "RegexUriReplacements": {
-            "car": "cars/([\\w\\d]+)/.+",
-            "color": "/([\\w\\d]+)$"
-          }
+    "MockSettings": [
+        {
+            "Id": "1",
+            "Request": {
+                "Methods": [
+                    "GET"
+                ],
+                "Path": "/"
+            },
+            "Response": {
+                "Status": 200,
+                "Headers": [
+                    {
+                        "Content-Type": "application/json"
+                    }
+                ],
+                "Body": "Welcome to MockServer"
+            }
+        },
+        {
+            "Id": "2",
+            "Request": {
+                "Methods": [
+                    "GET"
+                ],
+                "PathStartsWith": "/starts/with"
+            },
+            "Response": {
+                "Status": 200,
+                "Headers": [
+                    {
+                        "Content-Type": "application/json"
+                    }
+                ],
+                "Body": "{\"hello\":\"world\"}"
+            }
+        },
+        {
+            "Id": "3",
+            "Request": {
+                "Methods": [
+                    "GET"
+                ],
+                "PathMatchesRegex": "/\\d+"
+            },
+            "Response": {
+                "Status": 200,
+                "Headers": [
+                    {
+                        "Content-Type": "application/json"
+                    }
+                ],
+                "Body": null,
+                "BodyFromFilePath": "./responses/response.json"
+            }
+        },
+        {
+            "Id": "4",
+            "Request": {
+                "Methods": [ "GET" ],
+                "PathStartsWith": "/api/cars"
+            },
+            "Response": {
+                "Status": 200,
+                "Headers": [
+                    {
+                        "Content-Type": "application/json"
+                    }
+                ],
+                "Body": "{\"car\": \"ORDER-X\", \"color\": \"product-y\"}",
+                "Replace": {
+                    "RegexUriReplacements": {
+                        "car": "cars/([\\w\\d]+)/.+",
+                        "color": "/([\\w\\d]+)$"
+                    }
+                }
+            }
+        },
+        {
+            "Id": "5",
+            "Request": {
+                "Methods": [ "GET" ],
+                "PathMatchesRegex": ".+api/wines"
+            },
+            "Response": {
+                "Status": 200,
+                "Headers": [
+                    {
+                        "Content-Type": "application/json"
+                    }
+                ],
+                "BodyFromFilePath": "./responses/wine.json",
+                "Replace": {
+                    "UriTemplate": "wines/{wine}/{color}?year={year}",
+                    "UriPathReplacements": {
+                        "wine": "{wine}",
+                        "color": "{color}",
+                        "year": "{year}"
+                    }
+                }
+            }
         }
-      }
-    },
-    {
-      "Request": {
-        "Methods": [ "GET" ],
-        "PathMatchesRegex": ".+api/wines"
-      },
-      "Response": {
-        "Status": 200,
-        "Headers": [
-          {
-            "Content-Type": "application/json"
-          }
-        ],
-        "BodyFromFilePath": "./responses/wine.json",
-        "Replace": {
-          "UriTemplate": "wines/{wine}/{color}?year={year}",
-          "UriPathReplacements": {
-            "wine": "{wine}",
-            "color": "{color}",
-            "year": "{year}"
-          }
-        }
-      }
-    }
-  ]
+    ]
 }

--- a/readme.md
+++ b/readme.md
@@ -157,6 +157,15 @@ dotnet add package KestrelMock
    ]
 }
 ```
+## Example Mocks setup via admin endpoint
+
+admin endpoint '/kestrelmock/mocks'
+
+GET - returns list of mock settings objects.
+
+POST - body is expected to be HttpMockSetting and adds new mock
+
+DELETE - '/kestrelmock/mocks/YOURID' will delete by HttpMockSetting Id.
 
 ## Dynamic Mock
 


### PR DESCRIPTION
The endpoint is setup at '/kestrelmock/mocks'

GET - returns list of mock settings objects.
POST - body is expected to be HttpMockSetting and adds new mock
DELETE - '/kestrelmock/mocks/YOURID' will delete by HttpMockSetting Id.

fixes #40