### PR TITLE
leave stream open

### DIFF
--- a/KestrelMock/Services/MockService.cs
+++ b/KestrelMock/Services/MockService.cs
@@ -75,7 +75,7 @@ namespace KestrelMockServer.Services
 
             if (context.Request.Body != null)
             {
-                using StreamReader reader = new StreamReader(context.Request.Body);
+                using StreamReader reader = new StreamReader(context.Request.Body, leaveOpen: true);
                 body = await reader.ReadToEndAsync();
             }
 
@@ -127,7 +127,7 @@ namespace KestrelMockServer.Services
             }
             else if (context.Request.Method == HttpMethods.Post)
             {
-                using StreamReader reader = new StreamReader(context.Request.Body);
+                using StreamReader reader = new StreamReader(context.Request.Body, leaveOpen: true);
                 var body = await reader.ReadToEndAsync();
                 var setting = JsonConvert.DeserializeObject<HttpMockSetting>(body);
                 _mockConfiguration.Add(setting);

--- a/KestrelMock/Services/MockService.cs
+++ b/KestrelMock/Services/MockService.cs
@@ -75,7 +75,7 @@ namespace KestrelMockServer.Services
 
             if (context.Request.Body != null)
             {
-                using StreamReader reader = new StreamReader(context.Request.Body, leaveOpen: true);
+                using StreamReader reader = new StreamReader(context.Request.Body, default, true, -1, leaveOpen: true);
                 body = await reader.ReadToEndAsync();
             }
 
@@ -127,7 +127,7 @@ namespace KestrelMockServer.Services
             }
             else if (context.Request.Method == HttpMethods.Post)
             {
-                using StreamReader reader = new StreamReader(context.Request.Body, leaveOpen: true);
+                using StreamReader reader = new StreamReader(context.Request.Body, default, true, -1, leaveOpen: true);
                 var body = await reader.ReadToEndAsync();
                 var setting = JsonConvert.DeserializeObject<HttpMockSetting>(body);
                 _mockConfiguration.Add(setting);


### PR DESCRIPTION
leave stream open as source of possible bug is closed stream

```


ObjectDisposedException
--
  | error.exceptionmessage | Cannot access a closed Stream.
  | error.message | Connection id "0HMKN1UGS4NQU", Request id "0HMKN1UGS4NQU:00000002": An unhandled exception was thrown by the application.
  | error.rootexceptionmessage | [System.ObjectDisposedException]: Cannot access a closed Stream.
  | error.source | ACME.Common.Logging.AspNetLoggerProvider
  | error.stacktrace | at System.IO.MemoryStream.Seek(Int64 offset, SeekOrigin loc)    at ACME.Common.WebService.Middleware.Logging.ServerRequestResponseLoggingMiddleware.Invoke(HttpContext httpContext, ILoggerContext loggerContext, ICorrelationContextAccessor correlationContextAccessor)


```