### PR TITLE
F/observable mocks

### DIFF
--- a/KestrelMock.Tests/ObservableTests.cs
+++ b/KestrelMock.Tests/ObservableTests.cs
@@ -1,0 +1,93 @@
+using KestrelMockServer.Services;
+using KestrelMockServer.Settings;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Refit;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace KestrelMockServer.Tests
+{
+    public class ObservableTests : IClassFixture<MockTestApplicationFactory>
+    {
+        private readonly MockTestApplicationFactory _factory;
+
+        public ObservableTests(MockTestApplicationFactory factory)
+        {
+            _factory = factory;
+        }
+
+        [Theory]
+        [InlineData("/api/sendsomestuff")]
+        public async Task CanObservePut(string url)
+        {
+            var watchId = Guid.NewGuid();
+
+            // Arrange
+            var client = _factory.WithWebHostBuilder(b =>
+            {
+                b.ConfigureTestServices(services =>
+                {
+                    services.Configure<MockConfiguration>(opts =>
+                    {
+                        opts.Add(new HttpMockSetting
+                        {
+                            Request = new Request
+                            {
+                                PathStartsWith = url,
+                                Methods = new System.Collections.Generic.List<string>
+                                {
+                                    "PUT"
+                                }
+                            },
+                            Response = new Response
+                            {
+                                Status = 200,
+                                Body = "banana_x"
+                            },
+                            Watch = new Watch()
+                            {
+                                Id = watchId
+                            }
+                        });
+                    });
+
+                });
+            }).CreateClient();
+
+            // Act
+            var response = await client.PutAsync(url, new StringContent(JsonConvert.SerializeObject(new { Blah = "blah" })));
+
+            // Assert
+            response.EnsureSuccessStatusCode(); // Status Code 200-299
+
+            var message = await response.Content.ReadAsStringAsync();
+            Assert.Contains("banana_x", message);
+
+
+            //I can observe the data PUT to the mock
+            var observe = await client.GetAsync($"/kestrelmock/observe/{watchId}");
+
+            var observeContent = await observe.Content.ReadAsStringAsync();
+            Assert.Contains("PUT", observeContent);
+            Assert.Contains("Blah", observeContent);
+            Assert.Contains("blah", observeContent);
+
+            //It is cleared after observation meaning a second call does NOT return the data
+            observe = await client.GetAsync($"/kestrelmock/observe/{watchId}");
+
+            observeContent = await observe.Content.ReadAsStringAsync();
+            Assert.DoesNotContain("PUT", observeContent);
+            Assert.DoesNotContain("Blah", observeContent);
+            Assert.DoesNotContain("blah", observeContent);
+        }
+    }
+}

--- a/KestrelMock.Tests/ObservableTests.cs
+++ b/KestrelMock.Tests/ObservableTests.cs
@@ -72,7 +72,6 @@ namespace KestrelMockServer.Tests
             var message = await response.Content.ReadAsStringAsync();
             Assert.Contains("banana_x", message);
 
-
             //I can observe the data PUT to the mock
             var observe = await client.GetAsync($"/kestrelmock/observe/{watchId}");
 

--- a/KestrelMock/Domain/WatchLog.cs
+++ b/KestrelMock/Domain/WatchLog.cs
@@ -1,0 +1,18 @@
+﻿namespace KestrelMockServer.Domain
+{
+    public class WatchLog
+    {
+        public WatchLog(string path, string body, string method)
+        {
+            Path = path;
+            Body = body;
+            Method = method;
+        }
+
+        public string Path { get; }
+
+        public string Body { get; }
+
+        public string Method { get; }
+    }
+}

--- a/KestrelMock/Domain/Watcher.cs
+++ b/KestrelMock/Domain/Watcher.cs
@@ -19,7 +19,7 @@ namespace KestrelMockServer.Domain
             }
 
             watchLogs[watch.Id].Enqueue(watchLog);
-            if (watchLogs[watch.Id].Count > watch.NumberOfRequests)
+            if (watchLogs[watch.Id].Count > watch.RequestLogLimit)
             {
                 watchLogs[watch.Id].Dequeue();
             }

--- a/KestrelMock/Domain/Watcher.cs
+++ b/KestrelMock/Domain/Watcher.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using KestrelMockServer.Settings;
+
+namespace KestrelMockServer.Domain
+{
+    public class Watcher
+    {
+        private readonly Dictionary<Guid, Queue<WatchLog>> watchLogs = new Dictionary<Guid, Queue<WatchLog>>();
+
+        public void Log(string path, string body, string method, Watch watch)
+        {
+            var watchLog = new WatchLog(path, body, method);
+
+            if (!watchLogs.ContainsKey(watch.Id))
+            {
+                watchLogs.Add(watch.Id, new Queue<WatchLog>());
+            }
+
+            watchLogs[watch.Id].Enqueue(watchLog);
+            if (watchLogs[watch.Id].Count > watch.NumberOfRequests)
+            {
+                watchLogs[watch.Id].Dequeue();
+            }
+        }
+
+        public WatchLog[] GetWatchLogs(Guid watchId)
+        {
+            return watchLogs.ContainsKey(watchId)
+                ? DequeueAll(watchLogs[watchId])
+                : Array.Empty<WatchLog>();
+        }
+
+        private WatchLog[] DequeueAll(Queue<WatchLog> queue)
+        {
+            var list = new List<WatchLog>();
+
+            while (queue.Count > 0)
+            {
+                list.Add(queue.Dequeue());
+            }
+
+            return list.ToArray();
+        }
+
+        public void Remove(Guid watchId)
+        {
+            if (watchLogs.ContainsKey(watchId))
+            {
+                this.watchLogs.Remove(watchId);
+            }
+        }
+    }
+}

--- a/KestrelMock/KestrelMock.csproj
+++ b/KestrelMock/KestrelMock.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<PackageId>KestrelMock</PackageId>
-		<PackageVersion>0.4.0</PackageVersion>
+		<PackageVersion>0.5.1</PackageVersion>
 		<Authors>Jason Rowe</Authors>
 		<Description>.Net Core HTTP mocking server</Description>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/KestrelMock/Services/DynamicMockAddedResponse.cs
+++ b/KestrelMock/Services/DynamicMockAddedResponse.cs
@@ -7,5 +7,16 @@ namespace KestrelMockServer.Services
         public string Message { get; set; }
 
         public Watch Watch { get; set; }
+
+        public static DynamicMockAddedResponse Create(Watch watch)
+        {
+            return new DynamicMockAddedResponse
+            {
+                Message = watch == null
+                    ? "Dynamic mock added without observability."
+                    : $@"Dynamic mock added with observability, call /kestrelmock/observe/{watch.Id}",
+                Watch = watch
+            };
+        }
     }
 }

--- a/KestrelMock/Services/DynamicMockAddedResponse.cs
+++ b/KestrelMock/Services/DynamicMockAddedResponse.cs
@@ -1,0 +1,11 @@
+﻿using KestrelMockServer.Settings;
+
+namespace KestrelMockServer.Services
+{
+    public class DynamicMockAddedResponse
+    {
+        public string Message { get; set; }
+
+        public Watch Watch { get; set; }
+    }
+}

--- a/KestrelMock/Services/IResponseMatcherService.cs
+++ b/KestrelMock/Services/IResponseMatcherService.cs
@@ -5,6 +5,6 @@ namespace KestrelMockServer.Services
 {
     public interface IResponseMatcherService
     {
-        Response FindMatchingResponseMock(string path, string body, string method, InputMappings mapping);
+        Response FindMatchingResponseMock(string path, string body, string method, InputMappings mapping, Watcher watcher);
     }
 }

--- a/KestrelMock/Services/InputMappingParser.cs
+++ b/KestrelMock/Services/InputMappingParser.cs
@@ -45,8 +45,8 @@ namespace KestrelMockServer.Services
 
                             if (inputMappings.BodyCheckMapping.ContainsKey(key))
                             {
-                                var bodyContainesList = inputMappings.BodyCheckMapping[key];
-                                bodyContainesList.Add(httpMockSetting);
+                                var bodyContainsList = inputMappings.BodyCheckMapping[key];
+                                bodyContainsList.Add(httpMockSetting);
                             }
                             else
                             {

--- a/KestrelMock/Services/MockService.cs
+++ b/KestrelMock/Services/MockService.cs
@@ -139,7 +139,7 @@ namespace KestrelMockServer.Services
                 var body = await reader.ReadToEndAsync();
                 var setting = JsonConvert.DeserializeObject<HttpMockSetting>(body);
                 _mockConfiguration.Add(setting);
-                await context.Response.WriteAsync(JsonConvert.SerializeObject(MockAddSuccess(setting.Watch)));
+                await context.Response.WriteAsync(JsonConvert.SerializeObject(DynamicMockAddedResponse.Create(setting.Watch)));
             }
             else if (context.Request.Method == HttpMethods.Delete)
             {
@@ -156,17 +156,6 @@ namespace KestrelMockServer.Services
             }
 
             return true;
-        }
-
-        private DynamicMockAddedResponse MockAddSuccess(Watch watch)
-        {
-            return new DynamicMockAddedResponse
-            {
-                Message = watch == null
-                    ? "Dynamic mock added without observability."
-                    : @"Dynamic mock added with observability, call /kestrelmock/observe/[watchId]",
-                Watch = watch
-            };
         }
 
         protected async Task<bool> InvokeObserve(HttpContext context, Watcher watcher)

--- a/KestrelMock/Services/ObservableResponse.cs
+++ b/KestrelMock/Services/ObservableResponse.cs
@@ -1,0 +1,17 @@
+﻿using KestrelMockServer.Settings;
+
+namespace KestrelMockServer.Services
+{
+    public class ObservableResponse
+    {
+        public ObservableResponse(Response response, Watch watch)
+        {
+            Response = response;
+            Watch = watch;
+        }
+
+        public Response Response { get; }
+
+        public Watch Watch { get; }
+    }
+}

--- a/KestrelMock/Settings/HttpMockSetting.cs
+++ b/KestrelMock/Settings/HttpMockSetting.cs
@@ -7,5 +7,7 @@
         public Request Request { get; set; }
 
         public Response Response { get; set; }
+
+        public Watch Watch { get; set; }
     }
 }

--- a/KestrelMock/Settings/Response.cs
+++ b/KestrelMock/Settings/Response.cs
@@ -14,5 +14,5 @@ namespace KestrelMockServer.Settings
 		public string BodyFromFilePath { get; set; }
 
 		public Replace Replace { get; set; }
-	}
+    }
 }

--- a/KestrelMock/Settings/Watch.cs
+++ b/KestrelMock/Settings/Watch.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace KestrelMockServer.Settings
+{
+    public class Watch
+    {
+        public Guid Id { get; set; } = Guid.NewGuid();
+
+        public int NumberOfRequests { get; set; } = 10;
+    }
+}

--- a/KestrelMock/Settings/Watch.cs
+++ b/KestrelMock/Settings/Watch.cs
@@ -6,6 +6,6 @@ namespace KestrelMockServer.Settings
     {
         public Guid Id { get; set; } = Guid.NewGuid();
 
-        public int NumberOfRequests { get; set; } = 10;
+        public int RequestLogLimit { get; set; } = 10;
     }
 }

--- a/KestrelMockServer/appsettings.json
+++ b/KestrelMockServer/appsettings.json
@@ -100,6 +100,28 @@
                     }
                 }
             }
+        },
+        {
+            "Id": "6",
+            "Request": {
+                "Methods": [ "PUT" ],
+                "PathStartsWith": "/api/supplier"
+            },
+            "Response": {
+                "Status": 200,
+                "Headers": [
+                    {
+                        "Content-Type": "application/json"
+                    }
+                ],
+                "Body": "{\"hello\":\"test\"}",
+                "BodyFromFilePath": null,
+                "Replace": null
+            },
+            "Watch": {
+                "RequestLogLimit": 10,
+                "id": "c3f57f2c-b989-46eb-93a3-247a6caebe6d"
+            }
         }
     ]
 }

--- a/readme.md
+++ b/readme.md
@@ -167,6 +167,73 @@ POST - body is expected to be HttpMockSetting and adds new mock
 
 DELETE - '/kestrelmock/mocks/YOURID' will delete by HttpMockSetting Id.
 
+## Watch requests using observe endpoint
+
+observe endpoint '/kestrelmock/observe/[Watch id]'
+
+When adding the "Watch" object to your mock settings, an observe endpoint will be created to retrieve request data. The watch id can be added directly or retrieved via response of mock creation.
+
+```
+### Example post request to create mock with "Watch" object
+
+POST https://localhost:44391/kestrelmock/mocks
+Content-Type: application/json
+
+{
+   "Request": {
+      "Methods": [ "PUT" ],
+      "PathStartsWith": "/api/supplier"
+   },
+   "Response": {
+      "Status": 200,
+      "Headers": [
+         {
+         "Content-Type": "application/json"
+         }
+      ],
+      "Body": "{\"hello\":\"test\"}",
+      "BodyFromFilePath":null,
+      "Replace": null
+   },
+   "Watch": {
+      "RequestLogLimit": 10,
+      "Id": "c3f57f2c-b989-46eb-93a3-247a6caebe6d"
+   }
+}
+```
+
+Example of mock creation response from request above
+```
+{"Message":"Dynamic mock added with observability, call /kestrelmock/observe/c3f57f2c-b989-46eb-93a3-247a6caebe6d","Watch":{"Id":"c3f57f2c-b989-46eb-93a3-247a6caebe6d","RequestLogLimit":10}}
+```
+
+If you send the following request to a mocked endpoint which has a watch.
+```
+### Send request to mocked endpoint with body data to test
+
+PUT https://localhost:44391/api/supplier
+Content-Type: application/json
+
+{
+   "Test" : "foo"
+}
+```
+
+Then you can call the observe endpoint to see that request body from previous requests up to the limit. The request to the observe endpoint will clear all current data from the watch queue.
+```
+### See your requests using observe endpoint
+
+GET https://localhost:44391/kestrelmock/observe/c3f57f2c-b989-46eb-93a3-247a6caebe6d
+Content-Type: application/json
+```
+
+The observe endpoint will give you back the body. Example respons:
+
+```
+[{"Path":"/api/supplier","Body":"{\r\n   \"Test\" : \"foo\"\r\n}","Method":"PUT"}]
+```
+
+
 ## Dynamic Mock
 
 Some advanced dynamic mocking capabilities are provided for Json body data responses


### PR DESCRIPTION
![kestrel-mock](https://github.com/JasonRowe/KestrelMock/assets/7963468/371160c4-18d5-407a-a193-509d668e34e9)

I've added observable mocks - by default they will not be created with observability.  Presence of the `Watch` property triggers the observable behaviour.  Now adding a dynamic mock returns a piece of JSON where you can get info on calling the observability.

```{"Message":"Dynamic mock added with observability, call /kestrelmock/observe/f860d663-f191-4a41-86b8-06aa40b2b563","Watch":{"Id":"f860d663-f191-4a41-86b8-06aa40b2b563","RequestLogLimit":15}}```

In order to try and conserve memory, I've limited it to a default of 10 requests, but easily configurable higher.

I'd say my most contentious design choice is doing the GET on the observable API clears the cache.  So if you call it a couple of times, you'll get an empty array on the second request unless there has been anymore requests.

Feedback welcome, especially around that design choice, maybe they should stay?  (They're limited to the last x anyway.)