### PR TITLE
Handles a couple of null cases to avoid 500 errors being thrown

### DIFF
--- a/KestrelMock/Services/DynamicMockAddedResponse.cs
+++ b/KestrelMock/Services/DynamicMockAddedResponse.cs
@@ -8,14 +8,28 @@ namespace KestrelMockServer.Services
 
         public Watch Watch { get; set; }
 
-        public static DynamicMockAddedResponse Create(Watch watch)
+        public static DynamicMockAddedResponse Create(HttpMockSetting settings)
         {
+            if (settings == null)
+            {
+                return new DynamicMockAddedResponse()
+                {
+                    Message = "Dynamic mock settings were null, please check your request."
+                };
+            }
+
+            if (settings.Watch == null)
+            {
+                return new DynamicMockAddedResponse
+                {
+                    Message = "Dynamic mock added without observability."
+                };
+            }
+
             return new DynamicMockAddedResponse
             {
-                Message = watch == null
-                    ? "Dynamic mock added without observability."
-                    : $@"Dynamic mock added with observability, call /kestrelmock/observe/{watch.Id}",
-                Watch = watch
+                Message = $@"Dynamic mock added with observability, call /kestrelmock/observe/{settings.Watch.Id}",
+                Watch = settings.Watch
             };
         }
     }

--- a/KestrelMock/Services/MockService.cs
+++ b/KestrelMock/Services/MockService.cs
@@ -143,10 +143,10 @@ namespace KestrelMockServer.Services
             }
             else if (context.Request.Method == HttpMethods.Delete)
             {
-                var pathNotrailingString = context.Request.Path.ToString().TrimEnd('/');
-                var id = pathNotrailingString.Split('/').Last();
+                var pathNoTrailingString = context.Request.Path.ToString().TrimEnd('/');
+                var id = pathNoTrailingString.Split('/').Last();
 
-                var watch = _mockConfiguration.FirstOrDefault(setting => setting.Id == id).Watch;
+                var watch = _mockConfiguration.FirstOrDefault(setting => setting.Id == id)?.Watch;
                 if (watch != null)
                 {
                     watcher.Remove(watch.Id);

--- a/KestrelMock/Services/MockService.cs
+++ b/KestrelMock/Services/MockService.cs
@@ -139,7 +139,7 @@ namespace KestrelMockServer.Services
                 var body = await reader.ReadToEndAsync();
                 var setting = JsonConvert.DeserializeObject<HttpMockSetting>(body);
                 _mockConfiguration.Add(setting);
-                await context.Response.WriteAsync(JsonConvert.SerializeObject(DynamicMockAddedResponse.Create(setting.Watch)));
+                await context.Response.WriteAsync(JsonConvert.SerializeObject(DynamicMockAddedResponse.Create(setting)));
             }
             else if (context.Request.Method == HttpMethods.Delete)
             {


### PR DESCRIPTION
Issue 1: Calling delete twice on a Mock caused a 500.

Issue 2: Found that if settings were missing or badly formed then a 500 could be thrown.