### PR TITLE
fix concurrency issues where List<> is being used

### DIFF
--- a/KestrelMock.Tests/ObservableTests.cs
+++ b/KestrelMock.Tests/ObservableTests.cs
@@ -31,7 +31,7 @@ public class ObservableTests : IClassFixture<MockTestApplicationFactory>
             {
                 services.Configure<MockConfiguration>(opts =>
                 {
-                    opts.Add(new HttpMockSetting
+                    var setting = new HttpMockSetting
                     {
                         Request = new Request
                         {
@@ -50,7 +50,8 @@ public class ObservableTests : IClassFixture<MockTestApplicationFactory>
                         {
                             Id = watchId
                         }
-                    });
+                    };
+                    opts.TryAdd(setting.Id, setting);
                 });
 
             });

--- a/KestrelMock/Domain/Watcher.cs
+++ b/KestrelMock/Domain/Watcher.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using KestrelMockServer.Settings;
 
@@ -7,7 +7,7 @@ namespace KestrelMockServer.Domain
 {
     public class Watcher
     {
-        private readonly Dictionary<Guid, Queue<WatchLog>> watchLogs = new Dictionary<Guid, Queue<WatchLog>>();
+        private readonly ConcurrentDictionary<Guid, Queue<WatchLog>> watchLogs = new ConcurrentDictionary<Guid, Queue<WatchLog>>();
 
         public void Log(string path, string body, string method, Watch watch)
         {
@@ -15,7 +15,7 @@ namespace KestrelMockServer.Domain
 
             if (!watchLogs.ContainsKey(watch.Id))
             {
-                watchLogs.Add(watch.Id, new Queue<WatchLog>());
+                watchLogs.TryAdd(watch.Id, new Queue<WatchLog>());
             }
 
             watchLogs[watch.Id].Enqueue(watchLog);
@@ -48,7 +48,7 @@ namespace KestrelMockServer.Domain
         {
             if (watchLogs.ContainsKey(watchId))
             {
-                this.watchLogs.Remove(watchId);
+                this.watchLogs.TryRemove(watchId, out var mockFound);
             }
         }
     }

--- a/KestrelMock/Services/InputMappingParser.cs
+++ b/KestrelMock/Services/InputMappingParser.cs
@@ -28,8 +28,10 @@ namespace KestrelMockServer.Services
                 return inputMappings;
             }
 
-            foreach (var httpMockSetting in mockConfiguration)
+            foreach (var mockConfigItem in mockConfiguration)
             {
+                var httpMockSetting = mockConfigItem.Value;
+
                 if (!string.IsNullOrEmpty(httpMockSetting.Request.Path))
                 {
                     if (!string.IsNullOrEmpty(httpMockSetting.Request.BodyContains)

--- a/KestrelMock/Settings/HttpMockSetting.cs
+++ b/KestrelMock/Settings/HttpMockSetting.cs
@@ -1,8 +1,10 @@
-﻿namespace KestrelMockServer.Settings
+﻿using System;
+
+namespace KestrelMockServer.Settings
 {
     public class HttpMockSetting
     {
-        public string Id { get; set; }
+        public string Id { get; set; } = Guid.NewGuid().ToString();
 
         public Request Request { get; set; }
 

--- a/KestrelMock/Settings/MockConfiguration.cs
+++ b/KestrelMock/Settings/MockConfiguration.cs
@@ -1,8 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
 
 namespace KestrelMockServer.Settings
 {
-    public class MockConfiguration : List<HttpMockSetting>
+    public class MockConfiguration : ConcurrentDictionary<string, HttpMockSetting>
 	{
 	}
 }

--- a/KestrelMock/Startup.cs
+++ b/KestrelMock/Startup.cs
@@ -1,4 +1,6 @@
-﻿using KestrelMockServer.Services;
+﻿using System.Collections.Generic;
+using System.Linq;
+using KestrelMockServer.Services;
 using KestrelMockServer.Settings;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
@@ -24,7 +26,17 @@ namespace KestrelMockServer
             services.AddTransient<IResponseMatcherService, ResponseMatcherService>();
             services.AddTransient<IInputMappingParser, InputMappingParser>();
             services.AddTransient<IUriPathReplaceService, UriPathReplaceService>();
-            services.Configure<MockConfiguration>(configuration.GetSection("MockSettings"));
+            services.Configure<MockConfiguration>(opts => 
+            {
+                var mockSettings = configuration
+                    .GetSection("MockSettings")?
+                    .Get<List<HttpMockSetting>>() ?? Enumerable.Empty<HttpMockSetting>();
+
+                foreach (var setting in mockSettings)
+                {
+                    opts.TryAdd(setting.Id, setting);
+                }
+            });
         }
 
         public void Configure(IApplicationBuilder app)


### PR DESCRIPTION
Fix concurrency issues when multiple API calls happen very close to one another for:
- Adding/Deleting MockSettings
- Adding/Deleting Watchers