### PR TITLE
Fix for mocks that use multiple bodycontains with same path and concurrency hardening

### DIFF
--- a/KestrelMock/Domain/BodyCheckMapping.cs
+++ b/KestrelMock/Domain/BodyCheckMapping.cs
@@ -1,10 +1,9 @@
-﻿using KestrelMockServer.Settings;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using KestrelMockServer.Settings;
 
 namespace KestrelMockServer.Domain
 {
-    public sealed class BodyCheckMapping : ConcurrentDictionary<PathMappingKey, List<HttpMockSetting>>
+    public sealed class BodyCheckMapping : ConcurrentDictionary<PathMappingKey, ConcurrentBag<HttpMockSetting>>
     {
 
     }

--- a/KestrelMock/Services/InputMappingParser.cs
+++ b/KestrelMock/Services/InputMappingParser.cs
@@ -2,6 +2,7 @@
 using KestrelMockServer.Settings;
 using Microsoft.Extensions.Options;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -53,7 +54,7 @@ namespace KestrelMockServer.Services
                             }
                             else
                             {
-                                inputMappings.BodyCheckMapping.TryAdd(key, new List<HttpMockSetting> { httpMockSetting });
+                                inputMappings.BodyCheckMapping.TryAdd(key, new ConcurrentBag<HttpMockSetting>() { httpMockSetting });
                             }
                         }
                     }

--- a/KestrelMock/Services/ResponseMatcherService.cs
+++ b/KestrelMock/Services/ResponseMatcherService.cs
@@ -74,6 +74,12 @@ namespace KestrelMockServer.Services
                 foreach (var possibleResult in possibleResults)
                 {
                     result = CheckBodyMapping(body, method, possibleResult);
+
+                    // We found it, don't need to iterate anymore
+                    if (result != null)
+                    {
+                        break;
+                    }
                 }
             }
 


### PR DESCRIPTION
- Fix for mocks that use multiple bodycontains with same path
- Add a bit more concurrency help for BodyCheckMapping